### PR TITLE
made default exponential backoff more sane

### DIFF
--- a/worker/worker.go
+++ b/worker/worker.go
@@ -29,7 +29,7 @@ func sleepBetweenRetries(previousDuration time.Duration) time.Duration {
 	if previousDuration >= 60*time.Second {
 		return previousDuration
 	}
-	return previousDuration * previousDuration
+	return previousDuration + previousDuration
 }
 
 var GoCodeRunner = []byte(`#!/bin/sh
@@ -118,8 +118,8 @@ func (w *Worker) WaitForTask(taskId string) chan TaskInfo {
 			}
 
 			if info.Status == "queued" || info.Status == "running" {
-				retryDelay = sleepBetweenRetries(retryDelay)
 				time.Sleep(retryDelay)
+				retryDelay = sleepBetweenRetries(retryDelay)
 			} else {
 				out <- info
 				return
@@ -142,8 +142,8 @@ func (w *Worker) WaitForTaskLog(taskId string) chan []byte {
 			if err != nil {
 				e, ok := err.(api.HTTPResponseError)
 				if ok && e.Response().StatusCode == 404 {
-					retryDelay = sleepBetweenRetries(retryDelay)
 					time.Sleep(retryDelay)
+					retryDelay = sleepBetweenRetries(retryDelay)
 					continue
 				}
 				return


### PR DESCRIPTION
2777h46m40s was the default wait.

also, most implementations of exponential backoff used for non-collision
based issues that I've seen simply use a factor of 2 (this was a factor
of N) that are seeded at some interval in [milli]seconds.

I think this was the intent with the conditional being 60 seconds.

The func for exponential backoff mentions that people should use their
own implementation. I guess this expects users to implement the worker
interface's method with their own polling algo? A sane default sounds
nice, but if the default is intended to be implement your own shouldn't
we pass a `func (time.Duration) time.Duration` as a param?
