### PR TITLE
Add SetSubscribers and AddSubscribers functions and tests

### DIFF
--- a/mq/mq_test.go
+++ b/mq/mq_test.go
@@ -2,6 +2,7 @@ package mq_test
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 	"time"
 
@@ -122,6 +123,60 @@ func TestEverything(t *testing.T) {
 			Expect(info.Id, ToEqual, rc.Id)
 		})
 	})
+
+	It("tests new AddSubscribers function", func() {
+		subQueue := mq.New("AddSubscribersQueue-" + strconv.Itoa(time.Now().Nanosecond()))
+		defer subQueue.Delete()
+		subscription := mq.Subscription{PushType: "multicast"}
+		err := subQueue.AddSubscribers(subscription, "http://server1/")
+		Expect(err, ToBeNil)
+		info, err := subQueue.Info()
+		Expect(err, ToBeNil)
+		Expect(len(info.Subscribers), ToEqual, 1)
+		err = subQueue.AddSubscribers(subscription, "http://server2/")
+		Expect(err, ToBeNil)
+		info, err = subQueue.Info()
+		Expect(err, ToBeNil)
+		Expect(len(info.Subscribers), ToEqual, 2)
+	})
+
+	It("tests new SetSubscribers function", func() {
+		subQueue := mq.New("SetSubscribersQueue-" + strconv.Itoa(time.Now().Nanosecond()))
+		defer subQueue.Delete()
+		subscription := mq.Subscription{PushType: "multicast"}
+		err := subQueue.AddSubscribers(subscription, "http://server1/")
+		Expect(err, ToBeNil)
+		info, err := subQueue.Info()
+		Expect(err, ToBeNil)
+		Expect(len(info.Subscribers), ToEqual, 1)
+		err = subQueue.SetSubscribers(subscription, "http://server2/", "http://server3/", "http://server4/")
+		Expect(err, ToBeNil)
+		info, err = subQueue.Info()
+		Expect(err, ToBeNil)
+		Expect(len(info.Subscribers), ToEqual, 3)
+		err = subQueue.AddSubscribers(subscription, "http://server5/")
+		Expect(err, ToBeNil)
+		info, err = subQueue.Info()
+		Expect(err, ToBeNil)
+		Expect(len(info.Subscribers), ToEqual, 4)
+	})
+
+	It("tests original Subscribe function", func() {
+		subQueue := mq.New("Subscribe-" + strconv.Itoa(time.Now().Nanosecond()))
+		defer subQueue.Delete()
+		subscription := mq.Subscription{PushType: "multicast"}
+		err := subQueue.Subscribe(subscription, "http://server1/")
+		Expect(err, ToBeNil)
+		info, err := subQueue.Info()
+		Expect(err, ToBeNil)
+		Expect(len(info.Subscribers), ToEqual, 1)
+		err = subQueue.Subscribe(subscription, "http://server2/", "http://server3/", "http://server4/")
+		Expect(err, ToBeNil)
+		info, err = subQueue.Info()
+		Expect(err, ToBeNil)
+		Expect(len(info.Subscribers), ToEqual, 3)
+	})
+
 }
 
 func init() {


### PR DESCRIPTION
Added AddSubscribers() - fetches any existing subscribers and adds them to the new subscriber list.

Added SetSubscribers() - uses the logic that Subscribe() had to make the effect clearer
Changed Subscribe() to just call SetSubscribers()

Added test cases:
AddSubscribers - when called twice with a single distinct subscriber URL each time that there are two subscriptions

SetSubscribers - call AddSubscribers() once, call SetSubscribers() once with three different URLs, verify there are only three subscriptions, call AddSubscribers() with another unique subscriber, verify there are four subscriptions

Subscribe - call AddSubscribers() once, call Subscribe() with three different URLs, verify there are only three subscriptions
