### PR TITLE
Add package-level error ErrNoMessages, returned when no more messages are present in the current queue

### DIFF
--- a/mq/mq.go
+++ b/mq/mq.go
@@ -1,4 +1,4 @@
-// IronMQ (elastic message queue) client library
+// Package mq contains the IronMQ (elastic message queue) Go client library
 package mq
 
 import (
@@ -15,16 +15,19 @@ var (
 	ErrNoMessages = errors.New("mq: Couldn't get a single message")
 )
 
+// Queue represents an IronMQ message queue
 type Queue struct {
 	Settings config.Settings
 	Name     string
 }
 
+// QueueSubscriber represents a HTTP endpoint subscriber for an IronMQ message queue
 type QueueSubscriber struct {
 	URL     string            `json:"url"`
 	Headers map[string]string `json:"headers,omitempty"`
 }
 
+// QueueInfo represents information about an IronMQ message queue
 type QueueInfo struct {
 	Id            string            `json:"id,omitempty"`
 	Name          string            `json:"name,omitempty"`
@@ -39,6 +42,7 @@ type QueueInfo struct {
 	ErrorQueue    string            `json:"error_queue,omitempty"`
 }
 
+// Message represents a message which can be sent and retrieved from an IronMQ message queue
 type Message struct {
 	Id   string `json:"id,omitempty"`
 	Body string `json:"body"`
@@ -51,12 +55,15 @@ type Message struct {
 	q     Queue
 }
 
+// PushStatus represents the status of a pushed message to a subscriber
 type PushStatus struct {
 	Retried    int    `json:"retried"`
 	StatusCode int    `json:"status_code"`
 	Status     string `json:"status"`
 }
 
+// Subscriber represents an HTTP endpoint which retrieves information from an IronMQ message
+// queue, and the status of the subscriber
 type Subscriber struct {
 	Retried    int    `json:"retried"`
 	StatusCode int    `json:"status_code"`
@@ -64,6 +71,7 @@ type Subscriber struct {
 	URL        string `json:"url"`
 }
 
+// Alert represents an alert for a pull queue
 type Alert struct {
 	Type      string `json:"type"`
 	Direction string `json:direction`
@@ -71,10 +79,14 @@ type Alert struct {
 	Queue     string `queue`
 }
 
+// New returns a new Queue struct containing the specified name, and using the default settings
+// for an IronMQ message queue
 func New(queueName string) *Queue {
 	return &Queue{Settings: config.Config("iron_mq"), Name: queueName}
 }
 
+// ListQueues returns a slice of Queue structs, specifying the page and number of queues per
+// page to return from the API request
 func ListQueues(page, perPage int) (queues []Queue, err error) {
 	out := []struct {
 		Id         string
@@ -104,36 +116,43 @@ func ListQueues(page, perPage int) (queues []Queue, err error) {
 
 func (q Queue) queues(s ...string) *api.URL { return api.Action(q.Settings, "queues", s...) }
 
-// This method is left to support backward compatibility.
+// ListQueues method is left to support backward compatibility.
 // This method is replaced by func ListQueues(page, perPage int) (queues []Queue, err error)
 func (q Queue) ListQueues(page, perPage int) (queues []Queue, err error) {
 	return ListQueues(page, perPage)
 }
 
+// Info returns a QueueInfo struct containing information about the specified queue
 func (q Queue) Info() (QueueInfo, error) {
 	qi := QueueInfo{}
 	err := q.queues(q.Name).Req("GET", nil, &qi)
 	return qi, err
 }
 
+// Update modifies the queue information using the input QueueInfo struct
 func (q Queue) Update(qi QueueInfo) (QueueInfo, error) {
 	out := QueueInfo{}
 	err := q.queues(q.Name).Req("POST", qi, &out)
 	return out, err
 }
 
+// Delete deletes the current IronMQ message queue, returning both true and nil error
+// on success, or false and an error on failure
 func (q Queue) Delete() (bool, error) {
 	err := q.queues(q.Name).Req("DELETE", nil, nil)
 	success := err == nil
 	return success, err
 }
 
+// Subscription represents a HTTP endpoint subscription to an IronMQ message queue
 type Subscription struct {
 	PushType     string
 	Retries      int
 	RetriesDelay int
 }
 
+// Subscribe adds a subscription to an IronMQ message queue, with one or more subscribers
+// as specified by the variadic string argument
 func (q Queue) Subscribe(subscription Subscription, subscribers ...string) (err error) {
 	in := QueueInfo{
 		PushType:     subscription.PushType,
@@ -147,6 +166,8 @@ func (q Queue) Subscribe(subscription Subscription, subscribers ...string) (err 
 	return q.queues(q.Name).Req("POST", &in, nil)
 }
 
+// PushString pushes a simple string to an IronMQ message queue, and returns the ID
+// of the message
 func (q Queue) PushString(body string) (id string, err error) {
 	ids, err := q.PushStrings(body)
 	if err != nil {
@@ -155,7 +176,7 @@ func (q Queue) PushString(body string) (id string, err error) {
 	return ids[0], nil
 }
 
-// Push adds one or more messages to the end of the queue using IronMQ's defaults:
+// PushStrings adds one or more messages to the end of the queue using IronMQ's defaults:
 //	timeout - 60 seconds
 //	delay - none
 //
@@ -169,6 +190,8 @@ func (q Queue) PushStrings(bodies ...string) (ids []string, err error) {
 	return q.PushMessages(msgs...)
 }
 
+// PushMessage pushes a Message struct to an IronMQ message queue, and returns the ID
+// of the message
 func (q Queue) PushMessage(msg *Message) (id string, err error) {
 	ids, err := q.PushMessages(msg)
 	if err != nil {
@@ -177,6 +200,7 @@ func (q Queue) PushMessage(msg *Message) (id string, err error) {
 	return ids[0], nil
 }
 
+// PushMessages adds one or more messages to the end of an IronMQ message queue
 func (q Queue) PushMessages(msgs ...*Message) (ids []string, err error) {
 	in := struct {
 		Messages []*Message `json:"messages"`
@@ -211,13 +235,14 @@ func (q Queue) Get() (msg *Message, err error) {
 	return
 }
 
-// get N messages
+// GetN reserves N messages on the queue using the default timeout
 func (q Queue) GetN(n int) (msgs []*Message, err error) {
 	msgs, err = q.GetNWithTimeout(n, 0)
 
 	return
 }
 
+// GetNWithTimeout reserves N messages on the queue using the specified timeout
 func (q Queue) GetNWithTimeout(n, timeout int) (msgs []*Message, err error) {
 	out := struct {
 		Messages []*Message `json:"messages"`
@@ -238,6 +263,7 @@ func (q Queue) GetNWithTimeout(n, timeout int) (msgs []*Message, err error) {
 	return out.Messages, nil
 }
 
+// Peek looks at the next message on the queue, without reserving it
 func (q Queue) Peek() (msg *Message, err error) {
 	msgs, err := q.PeekN(1)
 	if err != nil {
@@ -253,13 +279,14 @@ func (q Queue) Peek() (msg *Message, err error) {
 	return
 }
 
-// peek N messages
+// PeekN looks at the next N messages on the queue using the default timeout
 func (q Queue) PeekN(n int) (msgs []*Message, err error) {
 	msgs, err = q.PeekNWithTimeout(n, 0)
 
 	return
 }
 
+// PeekNWithTimeout looks at the next N messages on the queue using the default timeout
 func (q Queue) PeekNWithTimeout(n, timeout int) (msgs []*Message, err error) {
 	out := struct {
 		Messages []*Message `json:"messages"`
@@ -280,42 +307,47 @@ func (q Queue) PeekNWithTimeout(n, timeout int) (msgs []*Message, err error) {
 	return out.Messages, nil
 }
 
-// Delete all messages in the queue
+// Clear deletes all messages in the queue
 func (q Queue) Clear() (err error) {
 	return q.queues(q.Name, "clear").Req("POST", nil, nil)
 }
 
-// Delete message from queue
-func (q Queue) DeleteMessage(msgId string) (err error) {
-	return q.queues(q.Name, "messages", msgId).Req("DELETE", nil, nil)
+// DeleteMessage removes a message with the specified ID from queue
+func (q Queue) DeleteMessage(msgID string) (err error) {
+	return q.queues(q.Name, "messages", msgID).Req("DELETE", nil, nil)
 }
 
-// Reset timeout of message to keep it reserved
-func (q Queue) TouchMessage(msgId string) (err error) {
-	return q.queues(q.Name, "messages", msgId, "touch").Req("POST", nil, nil)
+// TouchMessage resets the timeout of message with the specified ID, to keep it reserved
+func (q Queue) TouchMessage(msgID string) (err error) {
+	return q.queues(q.Name, "messages", msgID, "touch").Req("POST", nil, nil)
 }
 
-// Put message back in the queue, message will be available after +delay+ seconds.
-func (q Queue) ReleaseMessage(msgId string, delay int64) (err error) {
+// ReleaseMessage puts a message back in the queue, and then makes the message
+// available again after +delay+ seconds.
+func (q Queue) ReleaseMessage(msgID string, delay int64) (err error) {
 	in := struct {
 		Delay int64 `json:"delay"`
 	}{Delay: delay}
-	return q.queues(q.Name, "messages", msgId, "release").Req("POST", &in, nil)
+	return q.queues(q.Name, "messages", msgID, "release").Req("POST", &in, nil)
 }
 
-func (q Queue) MessageSubscribers(msgId string) ([]*Subscriber, error) {
+// MessageSubscribers returns a slice of Subscriber structs attached to the message
+// with the specified ID
+func (q Queue) MessageSubscribers(msgID string) ([]*Subscriber, error) {
 	out := struct {
 		Subscribers []*Subscriber `json:"subscribers"`
 	}{}
-	err := q.queues(q.Name, "messages", msgId, "subscribers").Req("GET", nil, &out)
+	err := q.queues(q.Name, "messages", msgID, "subscribers").Req("GET", nil, &out)
 	return out.Subscribers, err
 }
 
-func (q Queue) MessageSubscribersPollN(msgId string, n int) ([]*Subscriber, error) {
-	subs, err := q.MessageSubscribers(msgId)
+// MessageSubscribersPollN returns a slice of Subscriber structs attached to the message
+// with the specified ID, while also polling them to ensure that at least N are ready
+func (q Queue) MessageSubscribersPollN(msgID string, n int) ([]*Subscriber, error) {
+	subs, err := q.MessageSubscribers(msgID)
 	for {
 		time.Sleep(100 * time.Millisecond)
-		subs, err = q.MessageSubscribers(msgId)
+		subs, err = q.MessageSubscribers(msgID)
 		if err != nil {
 			return subs, err
 		}
@@ -336,6 +368,7 @@ func actualPushStatus(subs []*Subscriber) bool {
 	return true
 }
 
+// AddAlerts adds a variadic number of Alert structs to a pull queue
 func (q Queue) AddAlerts(alerts ...*Alert) (err error) {
 	in := struct {
 		Alerts []*Alert `json:"alerts"`
@@ -343,6 +376,7 @@ func (q Queue) AddAlerts(alerts ...*Alert) (err error) {
 	return q.queues(q.Name, "alerts").Req("POST", &in, nil)
 }
 
+// UpdateAlerts replaces a variadic number of Alert structs on a pull queue
 func (q Queue) UpdateAlerts(alerts ...*Alert) (err error) {
 	in := struct {
 		Alerts []*Alert `json:"alerts"`
@@ -350,43 +384,51 @@ func (q Queue) UpdateAlerts(alerts ...*Alert) (err error) {
 	return q.queues(q.Name, "alerts").Req("PUT", &in, nil)
 }
 
+// RemoveAllAlerts removes all alerts from an IronMQ message queue
 func (q Queue) RemoveAllAlerts() (err error) {
 	return q.queues(q.Name, "alerts").Req("DELETE", nil, nil)
 }
 
+// AlertInfo represents information about an alert
 type AlertInfo struct {
 	Id string `json:"id"`
 }
 
+// RemoveAlerts removes a variadic number of alerts with the specified alert IDs
+// from an IronMQ message queue
 func (q Queue) RemoveAlerts(alertIds ...string) (err error) {
 	in := struct {
 		Alerts []AlertInfo `json:"alerts"`
 	}{Alerts: make([]AlertInfo, len(alertIds))}
-	for i, alertId := range alertIds {
-		(in.Alerts[i]).Id = alertId
+	for i, alertID := range alertIds {
+		(in.Alerts[i]).Id = alertID
 	}
 	return q.queues(q.Name, "alerts").Req("DELETE", &in, nil)
 }
 
-func (q Queue) RemoveAlert(alertId string) (err error) {
-	return q.queues(q.Name, "alerts", alertId).Req("DELETE", nil, nil)
+// RemoveAlert removes a single alert with the specified alert ID from an IronMQ
+// message queue
+func (q Queue) RemoveAlert(alertID string) (err error) {
+	return q.queues(q.Name, "alerts", alertID).Req("DELETE", nil, nil)
 }
 
-// Delete message from queue
+// Delete removes a message from queue
 func (m Message) Delete() (err error) {
 	return m.q.DeleteMessage(m.Id)
 }
 
-// Reset timeout of message to keep it reserved
+// Touch reset the timeout of message to keep it reserved
 func (m Message) Touch() (err error) {
 	return m.q.TouchMessage(m.Id)
 }
 
-// Put message back in the queue, message will be available after +delay+ seconds.
+// Release puts a message back in the queue, and will make the message available
+// again after +delay+ seconds.
 func (m Message) Release(delay int64) (err error) {
 	return m.q.ReleaseMessage(m.Id, delay)
 }
 
+// Subscribers returns the subscribers attached to this message
 func (m Message) Subscribers() (interface{}, error) {
 	return m.q.MessageSubscribers(m.Id)
 }


### PR DESCRIPTION
Hello!  I noticed there was a little bit of error duplication in the `mq` package, so I added a package-level error, for easier error-checking.  This allows for the following:

``` go
for {
    // Get a message from the queue
    msg, err := queue.Get()
    if err == mq.ErrNoMessages {
        // Break loop on no messages
        break
    }

    // Check for other errors
    if err != nil && err != mq.ErrNoMessages {
        // Error is something unexpected
        log.Fatalf(err)
    }
}
```

Thanks for your time, and I look forward to digging in to IronMQ further!
