### PR TITLE
support long polling with GetNWithTimeoutAndWait

### DIFF
--- a/mq/mq.go
+++ b/mq/mq.go
@@ -219,12 +219,14 @@ func (q Queue) Get() (msg *Message, err error) {
 
 // get N messages
 func (q Queue) GetN(n int) (msgs []*Message, err error) {
-	msgs, err = q.GetNWithTimeout(n, 0)
-
-	return
+	return q.GetNWithTimeoutAndWait(n, 0, 0)
 }
 
 func (q Queue) GetNWithTimeout(n, timeout int) (msgs []*Message, err error) {
+	return q.GetNWithTimeoutAndWait(n, timeout, 0)
+}
+
+func (q Queue) GetNWithTimeoutAndWait(n, timeout, wait int) (msgs []*Message, err error) {
 	out := struct {
 		Messages []*Message `json:"messages"`
 	}{}
@@ -232,6 +234,7 @@ func (q Queue) GetNWithTimeout(n, timeout int) (msgs []*Message, err error) {
 	err = q.queues(q.Name, "messages").
 		QueryAdd("n", "%d", n).
 		QueryAdd("timeout", "%d", timeout).
+		QueryAdd("wait", "%d", wait).
 		Req("GET", nil, &out)
 	if err != nil {
 		return


### PR DESCRIPTION
This was the easy way to get things working in the Go library with long polling, but the API is starting to get unwieldy.  A better approach might be to create request objects, set parameters on them, and then call a `Do` method to actually do the work.  This is the pattern `http.Request` takes, for instance.
