### PR TITLE
Add progress infos to TaskInfo

### DIFF
--- a/worker/methods.go
+++ b/worker/methods.go
@@ -59,11 +59,11 @@ type TaskInfo struct {
 	Payload       string    `json:"payload"`
 	ProjectId     string    `json:"project_id"`
 	Status        string    `json:"status"`
-	Msg           string    `json:"msg"`
+	Msg           string    `json:"msg,omitempty"`
 	Duration      int       `json:"duration"`
 	RunTimes      int       `json:"run_times"`
 	Timeout       int       `json:"timeout"`
-	Percent       int       `json:"percent"`
+	Percent       int       `json:"percent,omitempty"`
 	CreatedAt     time.Time `json:"created_at"`
 	UpdatedAt     time.Time `json:"updated_at"`
 	StartTime     time.Time `json:"start_time"`


### PR DESCRIPTION
When querying for task's infos through the REST api, we get back a `percent` and `msg` fields when progress has been set.

The `TaskInfo` struct didn't reflect this, so I added them. The only issue with this is when there's no progress set, `percent` will be `0` and `msg` an empty string by default instead of not being included in the response like in the REST api.

Edit: fixed the issue about optional `percent` and `msg` fields with https://github.com/phacops/iron_go/commit/f437c5aee2125dc65ed5d13bdf814e2b1381bf50.
