### PR TITLE
Extract local variable client to package level

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -24,6 +24,9 @@ type URL struct {
 
 var (
 	debug bool
+
+	// HttpClient is the client used by iron_go to make each http request. It is exported in case
+	// the client would like to modify it from the default behavior from http.DefaultClient.
 	HttpClient = &http.Client{}
 )
 


### PR DESCRIPTION
This change allows to setup parameters of http.Client

```
q := mq.New("test")
api.HttpClient.Timeout = 20 * time.Second
q.PushString("Test")
```

Discussion available here: https://github.com/iron-io/iron_go/issues/28
