### PR TITLE
Cast delay as an integer

### DIFF
--- a/worker/methods.go
+++ b/worker/methods.go
@@ -247,7 +247,7 @@ func (w *Worker) TaskQueue(tasks ...Task) (taskIds []string, err error) {
 			thisTask["timeout"] = (*task.Timeout).Seconds()
 		}
 		if task.Delay != nil {
-			thisTask["delay"] = (*task.Delay).Seconds()
+			thisTask["delay"] = int64((*task.Delay).Seconds())
 		}
 
 		outTasks = append(outTasks, thisTask)


### PR DESCRIPTION
`Seconds` returns a `float64`. When sending this value to the API, we get back this error `400 Bad Request: In JSON, cannot use number 89837.238815739 as integer`.

Fix is to convert the delay to integer.
