### PR TITLE
Add possibility to initialize queue with inline settings

### DIFF
--- a/mq/mq.go
+++ b/mq/mq.go
@@ -69,6 +69,13 @@ func New(queueName string) *Queue {
 	return &Queue{Settings: config.Config("iron_mq"), Name: queueName}
 }
 
+// ConfigNew uses the specified settings over configuration specified in an iron.json file or
+// environment variables to return a Queue object capable of acquiring information about or
+// modifying the queue specified by queueName.
+func ConfigNew(queueName string, settings *config.Settings) Queue {
+	return Queue{Settings: config.ManualConfig("iron_mq", settings), Name: queueName}
+}
+
 func ListSettingsQueues(settings config.Settings, page int, perPage int) (queues []Queue, err error) {
 	out := []struct {
 		Id         string


### PR DESCRIPTION
This feature is needed for swapi (we need to have possibility to switch between v1-v3 in runtime depending on public or dedicated cluster required)