### PR TITLE
Fix Accept-Encoding header to match HTTP spec

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -111,7 +111,7 @@ func (u *URL) Request(method string, body io.Reader) (response *http.Response, e
 
 	request.Header.Set("Authorization", "OAuth "+u.Settings.Token)
 	request.Header.Set("Accept", "application/json")
-	request.Header.Set("Accept-Encoding", "gzip/deflate")
+	request.Header.Set("Accept-Encoding", "gzip, deflate")
 	request.Header.Set("User-Agent", u.Settings.UserAgent)
 
 	if body != nil {


### PR DESCRIPTION
Was sending `gzip/deflate` but the right value is `gzip, deflate`.  See http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.3