### PR TITLE
Remove Accept-Encoding header from requests

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -111,7 +111,6 @@ func (u *URL) Request(method string, body io.Reader) (response *http.Response, e
 
 	request.Header.Set("Authorization", "OAuth "+u.Settings.Token)
 	request.Header.Set("Accept", "application/json")
-	request.Header.Set("Accept-Encoding", "gzip/deflate")
 	request.Header.Set("User-Agent", u.Settings.UserAgent)
 
 	if body != nil {


### PR DESCRIPTION
The header had the wrong format (`gzip/deflate` instead of `gzip, deflate`) and was ignored by the server.  Setting the header is unnecessary, because Go's HTTP client transparently asks for and handles decompression.  If you manually set `Accept-Encoding` you must manually decompress the payload, which the library does not do.