### PR TITLE
make finding home dir cross compile friendly

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/user"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -121,14 +120,12 @@ func config(fullProduct, env string, configuration *Settings) Settings {
 }
 
 func (s *Settings) globalConfig(family, product, env string) {
-	u, err := user.Current()
+	home, err := homeDir()
 	if err != nil {
-		fmt.Println("Error getting user.Current():", err)
+		fmt.Println("Error getting home directory:", err)
 		return
-
 	}
-	//	fmt.Println("Homedir:", u.HomeDir)
-	path := filepath.Join(u.HomeDir, ".iron.json")
+	path := filepath.Join(home, ".iron.json")
 	s.UseConfigFile(family, product, path, env)
 }
 

--- a/config/homedir.go
+++ b/config/homedir.go
@@ -1,0 +1,83 @@
+//The MIT License (MIT)
+
+//Copyright (c) 2013 Mitchell Hashimoto
+
+//Permission is hereby granted, free of charge, to any person obtaining a copy
+//of this software and associated documentation files (the "Software"), to deal
+//in the Software without restriction, including without limitation the rights
+//to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//copies of the Software, and to permit persons to whom the Software is
+//furnished to do so, subject to the following conditions:
+
+//The above copyright notice and this permission notice shall be included in
+//all copies or substantial portions of the Software.
+
+//THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//THE SOFTWARE.
+//
+// This file is a wholesale copy of https://github.com/mitchellh/go-homedir@1f6da4a72e57d4e7edd4a7295a585e0a3999a2d4
+// with Dir() renamed to homeDir() and Expand() deleted.
+package config
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+// homeDir returns the home directory for the executing user.
+//
+// This uses an OS-specific method for discovering the home directory.
+// An error is returned if a home directory cannot be detected.
+func homeDir() (string, error) {
+	if runtime.GOOS == "windows" {
+		return dirWindows()
+	}
+
+	// Unix-like system, so just assume Unix
+	return dirUnix()
+}
+
+func dirUnix() (string, error) {
+	// First prefer the HOME environmental variable
+	if home := os.Getenv("HOME"); home != "" {
+		return home, nil
+	}
+
+	// If that fails, try the shell
+	var stdout bytes.Buffer
+	cmd := exec.Command("sh", "-c", "eval echo ~$USER")
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+
+	result := strings.TrimSpace(stdout.String())
+	if result == "" {
+		return "", errors.New("blank output when reading home directory")
+	}
+
+	return result, nil
+}
+
+func dirWindows() (string, error) {
+	drive := os.Getenv("HOMEDRIVE")
+	path := os.Getenv("HOMEPATH")
+	home := drive + path
+	if drive == "" || path == "" {
+		home = os.Getenv("USERPROFILE")
+	}
+	if home == "" {
+		return "", errors.New("HOMEDRIVE, HOMEPATH, and USERPROFILE are blank")
+	}
+
+	return home, nil
+}


### PR DESCRIPTION
haven't tested on windows, assuming it works since the package is pretty
well maintained. tested on my tux box and it works. need this to make
ironcli releases automated.

@treeder 