### PR TITLE
Add support for the -e flag

### DIFF
--- a/worker/remote.go
+++ b/worker/remote.go
@@ -10,6 +10,7 @@ import (
 
 var (
 	TaskDir     string
+	envFlag     string
 	payloadFlag string
 	TaskId      string
 	configFlag  string
@@ -18,6 +19,7 @@ var (
 // call this to parse flags before using the other methods.
 func ParseFlags() {
 	flag.StringVar(&TaskDir, "d", "", "task dir")
+	flag.StringVar(&envFlag, "e", "", "environment type")
 	flag.StringVar(&payloadFlag, "payload", "", "payload file")
 	flag.StringVar(&TaskId, "id", "", "task id")
 	flag.StringVar(&configFlag, "config", "", "config file")


### PR DESCRIPTION
Workers appear to pass an additional flag that this package doesn't support which is `-e` for environment.

How to reproduce:

```
package main

import (
    "fmt"
    "os"

    "github.com/iron-io/iron_go/worker"
)

func main() {
     fmt.Println(os.Args[1:])

     worker.ParseFlag()
}
```

And upload that as a worker. In my test I saw the following output:

```
[-d /mnt/task/ -e production -id 559db09c1aef8800070204f5 -payload /mnt/task/task_payload.json -config /mnt/task/__config__]

flag provided but not defined: -e
Usage of Worker:
  -config="": config file
  -d="": task dir
  -id="": task id
  -payload="": payload file
```

So this PR adds support for the additional `-e` flag and fixes the issue.