### PR TITLE
return nil error on http 201's

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -170,7 +170,7 @@ var HTTPErrorDescriptions = map[int]string{
 }
 
 func ResponseAsError(response *http.Response) HTTPResponseError {
-	if response.StatusCode == http.StatusOK {
+	if response.StatusCode == http.StatusOK || response.StatusCode == http.StatusCreated {
 		return nil
 	}
 


### PR DESCRIPTION
- we were returning status 201's as an error in `ResponseAsError` even though a 201 is a successful response on POST requests such as posting a message to an iron.io push queue
- I added 201's to the success check in `ResponseAsError` to solve this problem